### PR TITLE
forget best loss score

### DIFF
--- a/pytorch_toolbox/loader_base.py
+++ b/pytorch_toolbox/loader_base.py
@@ -32,7 +32,7 @@ class LoaderBase(Dataset):
         pass
 
     def __getitem__(self, index):
-        data, target = self.from_index(index)
+        data, target, info = self.from_index(index)
         if not isinstance(data, list):
             data = [data]
 
@@ -42,7 +42,7 @@ class LoaderBase(Dataset):
         for i, transform in enumerate(self.target_transforms):
             if transform is not None:
                 target[i] = transform(target[i])
-        return data, target
+        return data, target, info
 
     def __len__(self):
         return len(self.imgs)

--- a/pytorch_toolbox/loop_callback_base.py
+++ b/pytorch_toolbox/loop_callback_base.py
@@ -4,7 +4,7 @@ import csv
 
 class LoopCallbackBase(object):
     @abc.abstractmethod
-    def batch(self, predictions, network_inputs, targets, is_train=True, tensorboard_logger=None):
+    def batch(self, predictions, network_inputs, targets, info, is_train=True, tensorboard_logger=None):
         """
         Will be called after each minibatches
         :param predictions:

--- a/pytorch_toolbox/train_loop.py
+++ b/pytorch_toolbox/train_loop.py
@@ -138,7 +138,7 @@ class TrainLoop:
             data_var, target_var = self.to_autograd(data, target, is_train=True)
             y_pred = self.predict(data_var)
             loss = self.model.loss(y_pred, target_var)
-            losses.update(loss.data[0], data[0].size(0))
+            losses.update(loss.data.item(), data[0].size(0))
 
             self.optim.zero_grad()
             loss.backward()

--- a/pytorch_toolbox/train_loop.py
+++ b/pytorch_toolbox/train_loop.py
@@ -66,13 +66,13 @@ class TrainLoop:
         if backend == "cuda":
             for i in range(len(data)):
                 data[i] = data[i].cuda()
-            for i in range(len(target)):
-                target[i] = target[i].cuda()
+            # for i in range(len(target)):
+            #     target[i] = target[i].cuda()
         else:
             for i in range(len(data)):
                 data[i] = data[i].cpu()
-            for i in range(len(target)):
-                target[i] = target[i].cpu()
+            # for i in range(len(target)):
+            #     target[i] = target[i].cpu()
         return data, target
 
     @staticmethod
@@ -87,9 +87,9 @@ class TrainLoop:
         data_var = []
         for i in range(len(data)):
             data_var.append(torch.autograd.Variable(data[i], volatile=not is_train))
-        for i in range(len(target)):
-            target_var.append(torch.autograd.Variable(target[i], volatile=not is_train))
-        return data_var, target_var
+        # for i in range(len(target)):
+        #     target_var.append(torch.autograd.Variable(target[i], volatile=not is_train))
+        return data_var, target
 
     def predict(self, data_variable):
         """
@@ -159,7 +159,19 @@ class TrainLoop:
         return losses
 
     def test(self):
-        self.validate(0)
+        """
+        Test loop (refer to train())
+        """
+        self.model.eval()
+
+        for i, (data, target) in enumerate(self.valid_data):
+            data, target = self.setup_loaded_data(data, target, self.backend)
+            data_var, target_var = self.to_autograd(data, target, is_train=False)
+            y_pred = self.predict(data_var)
+
+            for i, callback in enumerate(self.callbacks):
+                callback.batch(y_pred, data, target, is_train=False, tensorboard_logger=self.tensorboard_logger)
+
 
     def validate(self, epoch):
         """
@@ -225,6 +237,7 @@ class TrainLoop:
                 dict, self.best_prec1, epoch_best = self.load_checkpoint(output_path, model_name)
                 if forget_best_prec:
                     self.best_prec1 = float('Inf')
+                print('best_prec: {}'.format(self.best_prec1))
                 self.model.load_state_dict(dict)
                 # also get back the last i_epoch, won't start from 0 again
                 self.epoch_start = epoch_best + 1
@@ -250,9 +263,9 @@ class TrainLoop:
         """
 
 
-        setup_checkpoint(load_best_checkpoint, load_last_checkpoint, output_path, forget_best_prec)
+        self.setup_checkpoint(load_best_checkpoint, load_last_checkpoint, output_path, forget_best_prec)
 
-        for epoch in range(epoch_start, epochs_qty):
+        for epoch in range(self.epoch_start, epochs_qty):
             print("-" * 20)
             print(" * EPOCH : {}".format(epoch))
 

--- a/pytorch_toolbox/train_loop.py
+++ b/pytorch_toolbox/train_loop.py
@@ -214,7 +214,8 @@ class TrainLoop:
              load_last_checkpoint=False,
              save_best_checkpoint=True,
              save_last_checkpoint=True,
-             save_all_checkpoints=True):
+             save_all_checkpoints=True,
+             forget_best_prec=False):
         """
         Training loop for n epoch.
         todo : Use callback instead of hardcoded savetxt to leave the user choise on results handling
@@ -233,6 +234,8 @@ class TrainLoop:
             model_name = 'model_best.pth.tar' if load_best_checkpoint else 'model_last.pth.tar'
             if os.path.exists(os.path.join(output_path, model_name)):
                 dict, best_prec1, epoch_best = self.load_checkpoint(output_path, model_name)
+                if forget_best_prec:
+                    best_prec1 = float('Inf')
                 self.model.load_state_dict(dict)
                 # also get back the last i_epoch, won't start from 0 again
                 epoch_start = epoch_best + 1

--- a/pytorch_toolbox/train_loop.py
+++ b/pytorch_toolbox/train_loop.py
@@ -173,7 +173,6 @@ class TrainLoop:
             for i, callback in enumerate(self.callbacks):
                 callback.batch(y_pred, data, target, info, is_train=False, tensorboard_logger=self.tensorboard_logger)
 
-
     def validate(self, epoch):
         """
         Validation loop (refer to train())
@@ -197,7 +196,7 @@ class TrainLoop:
             data_var, target_var = self.to_autograd(data, target, is_train=False)
             y_pred = self.predict(data_var)
             loss = self.model.loss(y_pred, target_var)
-            losses.update(loss.data[0], data[0].size(0))
+            losses.update(loss.data.item(), data[0].size(0))
 
             for i, callback in enumerate(self.callbacks):
                 callback.batch(y_pred, data, target, info, is_train=False, tensorboard_logger=self.tensorboard_logger)
@@ -206,7 +205,8 @@ class TrainLoop:
             end = time.time()
 
         for i, callback in enumerate(self.callbacks):
-            callback.epoch(epoch, losses.avg, data_time.avg, batch_time.avg, is_train=False, tensorboard_logger=self.tensorboard_logger)
+            callback.epoch(epoch, losses.avg, data_time.avg, batch_time.avg, is_train=False,
+                           tensorboard_logger=self.tensorboard_logger)
 
         return losses
 
@@ -226,8 +226,8 @@ class TrainLoop:
         epoch = state['epoch'] - 1
         return dict, self.best_prec1, epoch
 
-
-    def setup_checkpoint(self, load_best_checkpoint, load_last_checkpoint, output_path, forget_best_prec, model_name=[]):
+    def setup_checkpoint(self, load_best_checkpoint, load_last_checkpoint, output_path, forget_best_prec,
+                         model_name=[]):
         """
         Function to setup the desired checkpoint to be loaded (if desired)
         """
@@ -246,13 +246,8 @@ class TrainLoop:
             else:
                 raise RuntimeError("Can't load model {}".format(os.path.join(output_path, model_name)))
 
-    def loop(self, epochs_qty, output_path,
-             load_best_checkpoint=False,
-             load_last_checkpoint=False,
-             save_best_checkpoint=True,
-             save_last_checkpoint=True,
-             save_all_checkpoints=True,
-             forget_best_prec=False):
+    def loop(self, epochs_qty, output_path, load_best_checkpoint=False, load_last_checkpoint=False,
+             save_best_checkpoint=True, save_last_checkpoint=True, save_all_checkpoints=True, forget_best_prec=False):
         """
         Training loop for n epoch.
         todo : Use callback instead of hardcoded savetxt to leave the user choise on results handling
@@ -263,7 +258,6 @@ class TrainLoop:
         :param output_path:           Path to save the model and log data
         :return:
         """
-
 
         self.setup_checkpoint(load_best_checkpoint, load_last_checkpoint, output_path, forget_best_prec)
 
@@ -303,4 +297,3 @@ class TrainLoop:
     @staticmethod
     def to_np(x):
         return x.data.cpu().numpy()
-

--- a/pytorch_toolbox/train_loop.py
+++ b/pytorch_toolbox/train_loop.py
@@ -226,13 +226,14 @@ class TrainLoop:
         return dict, self.best_prec1, epoch
 
 
-    def setup_checkpoint(self, load_best_checkpoint, load_last_checkpoint, output_path, forget_best_prec):
+    def setup_checkpoint(self, load_best_checkpoint, load_last_checkpoint, output_path, forget_best_prec, model_name=[]):
         """
         Function to setup the desired checkpoint to be loaded (if desired)
         """
         assert not (load_best_checkpoint and load_last_checkpoint), 'Choose to load only one model: last or best'
         if load_best_checkpoint or load_last_checkpoint:
-            model_name = 'model_best.pth.tar' if load_best_checkpoint else 'model_last.pth.tar'
+            if model_name == []:
+                model_name = 'model_best.pth.tar' if load_best_checkpoint else 'model_last.pth.tar'
             if os.path.exists(os.path.join(output_path, model_name)):
                 dict, self.best_prec1, epoch_best = self.load_checkpoint(output_path, model_name)
                 if forget_best_prec:

--- a/pytorch_toolbox/train_loop.py
+++ b/pytorch_toolbox/train_loop.py
@@ -66,13 +66,13 @@ class TrainLoop:
         if backend == "cuda":
             for i in range(len(data)):
                 data[i] = data[i].cuda()
-            # for i in range(len(target)):
-            #     target[i] = target[i].cuda()
+            for i in range(len(target)):
+                target[i] = target[i].cuda()
         else:
             for i in range(len(data)):
                 data[i] = data[i].cpu()
-            # for i in range(len(target)):
-            #     target[i] = target[i].cpu()
+            for i in range(len(target)):
+                target[i] = target[i].cpu()
         return data, target
 
     @staticmethod
@@ -87,8 +87,8 @@ class TrainLoop:
         data_var = []
         for i in range(len(data)):
             data_var.append(torch.autograd.Variable(data[i], volatile=not is_train))
-        # for i in range(len(target)):
-        #     target_var.append(torch.autograd.Variable(target[i], volatile=not is_train))
+        for i in range(len(target)):
+            target_var.append(torch.autograd.Variable(target[i], volatile=not is_train))
         return data_var, target
 
     def predict(self, data_variable):

--- a/pytorch_toolbox/transformations/hdr.py
+++ b/pytorch_toolbox/transformations/hdr.py
@@ -56,7 +56,7 @@ class ToneMapper(object):
         tonemap_img = tonemap1.process(opencv_img)
         tonemap_img_8bit = np.clip(tonemap_img * 255, 0, 255).astype('uint8')
 
-        reshape_tonemap_img_8bit = np.empty([3, 64, 128])
+        reshape_tonemap_img_8bit = np.empty([3, 886634, 1])
         for i in range(3):
             reshape_tonemap_img_8bit[i, :, :] = tonemap_img_8bit[:, :, i]
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='pytorch_toolbox',


### PR DESCRIPTION
Add flag to allow one to load the network weights but to ignore the loss score obtained with those weights. This is useful when someone wants to change the loss function (thus the old loss score is not related to this new loss function) but using pretrained weights.