### PR TITLE
Update setup.py to include probe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     packages=['pytorch_toolbox',
               'pytorch_toolbox.visualization',
               'pytorch_toolbox.transformations',
+              'pytorch_toolbox.probe',
               'pytorch_toolbox.modules'],
     install_requires=['numpy', 'tqdm', 'visdom', 'pyyaml', 'scikit-image']
 )


### PR DESCRIPTION
The probe folder was not include in the `setup.py`.
This pull request add it.